### PR TITLE
Fix test on windows

### DIFF
--- a/tests/CounterTest.php
+++ b/tests/CounterTest.php
@@ -68,6 +68,10 @@ final class CounterTest extends TestCase
 
     public function testIncrementMustBeUniformAfterLimitIsReached(): void
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('On Windows, the "usleep()" function used in this test may not work correctly.');
+        }
+
         $counter = new Counter(10, 1, new ArrayCache());
         $counter->setId('key');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #11 

On Windows, the "usleep()" function used in tests may not work correctly (see [docs](https://www.php.net/manual/en/function.usleep.php)).

Test, used this function, will be skipped in this PR.